### PR TITLE
Slightly changed how `GetTxInfo` is processed to use a map for the result instead of a struct

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -111,22 +111,6 @@ type TxInfoRequest struct {
 	Full string `json:"full"`
 }
 
-// TxInfoResult is the success result returned from the api
-type TxInfoResult struct {
-	TimeCreated    string `json:"time_created"`
-	TimeExpires    string `json:"time_expires"`
-	Status         string `json:"status"`
-	StatusText     string `json:"status_text"`
-	Type           string `json:"type"`
-	Coin           string `json:"coin"`
-	Amount         string `json:"amount"`
-	Amountf        string `json:"amountf"`
-	Received       string `json:"received"`
-	Receivedf      string `json:"receivedf"`
-	RecvConfirms   string `json:"recv_confirms"`
-	PaymentAddress string `json:"payment_address"`
-}
-
 // TxInfoResponse is the response we receive from the API. The result field will not be populated on error.
 type TxInfoResponse struct {
 	ErrorResponse

--- a/tx.go
+++ b/tx.go
@@ -113,13 +113,24 @@ type TxInfoRequest struct {
 
 // TxInfoResult is the success result returned from the api
 type TxInfoResult struct {
-	Address string `json:"address"`
+	TimeCreated    string `json:"time_created"`
+	TimeExpires    string `json:"time_expires"`
+	Status         string `json:"status"`
+	StatusText     string `json:"status_text"`
+	Type           string `json:"type"`
+	Coin           string `json:"coin"`
+	Amount         string `json:"amount"`
+	Amountf        string `json:"amountf"`
+	Received       string `json:"received"`
+	Receivedf      string `json:"receivedf"`
+	RecvConfirms   string `json:"recv_confirms"`
+	PaymentAddress string `json:"payment_address"`
 }
 
 // TxInfoResponse is the response we receive from the API. The result field will not be populated on error.
 type TxInfoResponse struct {
 	ErrorResponse
-	Result TxInfoResult `json:"result"`
+	Result map[string]interface{} `json:"result"`
 }
 
 // CallGetTxInfo calls the get_tx_info command on the API

--- a/tx_test.go
+++ b/tx_test.go
@@ -1,11 +1,25 @@
 package coinpayments_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/etherparty/coinpayments"
 )
 
+func TestCallGetTxInfo(t *testing.T) {
+	client, err := testClient()
+	if err != nil {
+		t.Fatal("should have instantiated a new client with valid configuration")
+	}
+
+	resp, err := client.CallGetTxInfo(&coinpayments.TxInfoRequest{TxID: "CPCH77TFVEQDO2LBPYQZZZM7VR", Full: "0"})
+	if err != nil {
+		t.Fatal("error getting tx info ", err)
+	}
+
+	fmt.Printf("%+v\n", resp)
+}
 func TestCallCreateTransaction(t *testing.T) {
 	client, err := testClient()
 	if err != nil {


### PR DESCRIPTION
`GetTxInfo` API call from coinpayments has a response that can be "dynamic" and works best with a `map[string]interface{}` to create an easy to parse response.